### PR TITLE
CircleCI: use stack v1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ jobs:
       - image: fpco/stack-build:lts
     steps:
       - checkout
+      - debug_stack_version:
+          name: DEBUG stack version
+          command: stack --version
       - restore_cache:
           name: Restore cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: fpco/stack-build:lts
     steps:
       - checkout
-      - debug_stack_version:
+      - run:
           name: DEBUG stack version
           command: stack --version
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts
+      - image: fpco/stack-build:lts-12
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ jobs:
       - image: fpco/stack-build:lts-12
     steps:
       - checkout
-      - run:
-          name: DEBUG stack version
-          command: stack --version
       - restore_cache:
           name: Restore cache
           keys:


### PR DESCRIPTION
The `fpco/stack-build` `lts` image upgraded Stack to version 2, causing an error parsing `stack.yaml`:

```
Could not parse '/root/project/stack.yaml':
Aeson exception:
Error in $.packages[1]: failed to parse field 'packages': expected Text, encountered Object
See http://docs.haskellstack.org/en/stable/yaml_configuration/
Exited with code 1
```

this is fixed by using `lts-12` (which contains Stack version 1) instead of `lts`.