### PR TITLE
Simplify+clarify `OrderBook.Graph.Types.Path`

### DIFF
--- a/src/OrderBook/Graph.hs
+++ b/src/OrderBook/Graph.hs
@@ -215,8 +215,7 @@ toSideLiquidity nonEmptyOrders =
         (quoteSum paths, priceRange paths, pathDescr $ NE.head paths)
     groupByPath = NE.groupBy (\a b -> pathDescr a == pathDescr b) . sortOn pathDescr
     sortByQuantity = sortBy (flip $ comparing $ \(quoteQty, _, _) -> quoteQty)
-    quoteSum orderList = sum $ NE.map quoteQuantity orderList
-    quoteQuantity path = pQty path * pPrice path
+    quoteSum orderList = sum $ NE.map pQty orderList
     priceRange
         :: NE.NonEmpty path
         -> PriceRange NumType

--- a/src/OrderBook/Graph.hs
+++ b/src/OrderBook/Graph.hs
@@ -134,7 +134,7 @@ findArbitrages log gi graph = do
         T.unwords [toS (pStart . pathDescr $ head paths), toS . show @Double . realToFrac $ pathsQty paths]
         : map (("\t" <>) . showPath . head) (groupOn pathDescr paths)
     pathsQty :: [Path] -> NumType
-    pathsQty = sum . map pQty
+    pathsQty = sum . map pathQty
     groupOn f = groupBy (\a1 a2 -> f a1 == f a2) . sortOn f
 
 type IBuyGraph = (DG.IDigraph Currency (Tagged "buy" CompactOrderList))
@@ -203,7 +203,7 @@ toSideLiquidity
 toSideLiquidity nonEmptyOrders =
     let paths = NE.fromList $ sortByQuantity $ map quoteSumVenue (groupByPath $ NE.toList nonEmptyOrders)
     in SideLiquidity
-        { liLiquidity    = quoteSum nonEmptyOrders
+        { liLiquidity    = numeraireSum nonEmptyOrders
         , liPriceRange   = firstLastPrice nonEmptyOrders
         , liPaths        = paths
         }
@@ -212,10 +212,10 @@ toSideLiquidity nonEmptyOrders =
         let priceSorted = NE.sortBy (comparing pPrice) lst
         in PriceRange (pPrice $ NE.head priceSorted) (pPrice $ NE.last priceSorted)
     quoteSumVenue paths =
-        (quoteSum paths, priceRange paths, pathDescr $ NE.head paths)
+        (numeraireSum paths, priceRange paths, pathDescr $ NE.head paths)
     groupByPath = NE.groupBy (\a b -> pathDescr a == pathDescr b) . sortOn pathDescr
     sortByQuantity = sortBy (flip $ comparing $ \(quoteQty, _, _) -> quoteQty)
-    quoteSum orderList = sum $ NE.map pQty orderList
+    numeraireSum pathList = sum $ NE.map pQty pathList
     priceRange
         :: NE.NonEmpty path
         -> PriceRange NumType

--- a/src/OrderBook/Graph/Types/Path.hs
+++ b/src/OrderBook/Graph/Types/Path.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
--- {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 module OrderBook.Graph.Types.Path
 ( Path'
 , pathQty
@@ -156,7 +154,7 @@ showPathQty path =
                         (showPath path)
     in toS string
 
-
+-- | Path quantity in units of "crypto"
 pQtyCrypto
     :: ( HasPathQuantity path numType
        , Fractional numType

--- a/src/OrderBook/Graph/Types/Path.hs
+++ b/src/OrderBook/Graph/Types/Path.hs
@@ -90,19 +90,19 @@ newtype SellPath' numType = SellPath' { getSellPath :: Path' numType }
     deriving (Eq, Show, Ord, Generic, Functor)
 
 toBuyPath
-    :: Path' numType
-    -> BuyPath' numType
-toBuyPath = BuyPath'
-
-toSellPath
     :: Fractional numType
     => Path' numType
-    -> SellPath' numType
-toSellPath bp@Path'{..} = SellPath' $
-    bp
-      { _pPrice = recip $ _pPrice
+    -> BuyPath' numType
+toBuyPath sp@Path'{..} = BuyPath' $
+    sp
+      { _pPrice = recip _pPrice
       , _pQty   = _pQty * _pPrice
       }
+
+toSellPath
+    :: Path' numType
+    -> SellPath' numType
+toSellPath = SellPath'
 
 instance PrettyVal numType => PrettyVal (SellPath' numType)
 instance NFData numType => NFData (SellPath' numType)

--- a/src/OrderBook/Graph/Types/Path.hs
+++ b/src/OrderBook/Graph/Types/Path.hs
@@ -61,6 +61,7 @@ data Path' numType = Path'
     , _pQty   :: !numType
       -- ^ Unit: "destination currency"
       -- (e.g. /BTC/ for path @USD --venue--> BTC@)
+      --  Multiply by 'pPrice' to change unit to "source currency" (/USD/ in above example).
     , _pPath :: !PathDescr
       -- ^ Actual path
     } deriving (Eq, Show, Generic, Functor)

--- a/src/OrderBook/Graph/Types/Path.hs
+++ b/src/OrderBook/Graph/Types/Path.hs
@@ -88,8 +88,7 @@ newtype SellPath' numType = SellPath' { getSellPath :: Path' numType }
     deriving (Eq, Show, Ord, Generic, Functor)
 
 toBuyPath
-    :: Fractional numType
-    => Path' numType
+    :: Path' numType
     -> BuyPath' numType
 toBuyPath = BuyPath'
 

--- a/test/Common/Util.hs
+++ b/test/Common/Util.hs
@@ -88,7 +88,7 @@ assertMatchedOrders sellOrders buyOrder f = void $ do
         mGraph <- Lib.buildFromOrders shuffledSellOrders
         (buyGraph, _) <- Lib.runArb mGraph $ Lib.arbitrages base >> Lib.arbitrages quote
         buyPaths <- Lib.runMatch buyGraph $ Lib.match buyOrder
-        return $ map Lib.toSellOrder buyPaths
+        return $ map Lib.pathToSellOrder buyPaths
     assertAscendingPriceSorted matchedOrders
     f (merge matchedOrders)
   where

--- a/test/Unit/Integration.hs
+++ b/test/Unit/Integration.hs
@@ -30,7 +30,7 @@ matchBuyPath =
     TestCase $ ST.runST (matchOrderBooks [orderBook])
         `shouldBe` ([], ["10.0 @ 10000.0" <> path, "20.0 @ 11000.0" <> path])
   where
-    orderBook :: Lib.OrderBook Double
+    orderBook :: Lib.OrderBook Rational
     orderBook = Lib.mkOrderBook bids asks "TestVenue" "BTC" "USD"
     path = " USD --TestVenue--> BTC"
     bids = Vec.fromList []
@@ -42,7 +42,7 @@ matchSellPath =
     TestCase $ ST.runST (matchOrderBooks [orderBook])
         `shouldBe` (["5.0 @ 9000.0" <> path, "15.0 @ 8500.0" <> path], [])
   where
-    orderBook :: Lib.OrderBook Double
+    orderBook :: Lib.OrderBook Rational
     orderBook = Lib.mkOrderBook bids asks "TestVenue" "BTC" "USD"
     path = " BTC --TestVenue--> USD"
     bids = Vec.fromList [Lib.mkOrder 5 9000, Lib.mkOrder 15 8500]
@@ -56,7 +56,7 @@ matchSellBuyPath =
                    , ["3.0 @ 7500.0" <> pathBuy, "1.5 @ 7700.0" <> pathBuy]
                    )
   where
-    orderBook :: Lib.OrderBook Double
+    orderBook :: Lib.OrderBook Rational
     orderBook = Lib.mkOrderBook bids asks "TestVenue" "BTC" "USD"
     pathSell = " BTC --TestVenue--> USD"
     pathBuy = " USD --TestVenue--> BTC"
@@ -74,9 +74,9 @@ matchOrderBooks orderBooks = do
         , map (Lib.showPathQty . buyPathDouble) buyPaths
         )
   where
-    sellPathDouble :: Lib.SellPath -> Lib.SellPath' Double
+    sellPathDouble :: Lib.SellPath -> Lib.SellPath' Rational
     sellPathDouble = fmap fromRational
-    buyPathDouble :: Lib.BuyPath -> Lib.BuyPath' Double
+    buyPathDouble :: Lib.BuyPath -> Lib.BuyPath' Rational
     buyPathDouble = fmap fromRational
     noLogging :: Monad m => String -> m ()
     noLogging = const $ return ()


### PR DESCRIPTION
* `OrderBook.Graph.Types.Path`:
   * simplify+clarify 
   * Remove `HasPathQuantity Path’` instance
* remove unused functionality in `OrderBook.Graph.Match.Types`
   * TODO: remove everything?
* improve docs